### PR TITLE
profile取得APIで失敗した際のレスポンスのステータスコードを403に変更

### DIFF
--- a/src/controllers/user/user.controller.ts
+++ b/src/controllers/user/user.controller.ts
@@ -7,7 +7,7 @@ import {
   Body,
   Delete,
   Inject,
-  BadRequestException,
+  ForbiddenException,
 } from '@nestjs/common';
 import {
   ApiOperation,
@@ -47,9 +47,10 @@ export class UserController {
     type: UserPresenter,
   })
   async getProfile(@Req() req: Request) {
-    return req.currentUser
-      ? new UserPresenter(req.currentUser)
-      : new BadRequestException();
+    if (!req.currentUser) {
+      throw new ForbiddenException('Access to this resource is forbidden');
+    }
+    return new UserPresenter(req.currentUser);
   }
 
   @Patch(':id')


### PR DESCRIPTION
# チケット
[SHARE-98](https://linear.app/ryotanny/issue/SHARE-98/usersprofileで400エラーのレスポンスがstatuscode200で返ってくる)

# 概要
元々、リクエストのユーザー情報が`null`の場合、400エラーのメッセージがステータスコード200で返っていた

# 変更点
リクエストのユーザー情報が`null`の場合、アプリ側の都合で区別したいので、403を返すように変更