### PR TITLE
ユーザーのプッシュ通知用のトークンを管理できるように変更

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -56,6 +56,26 @@ paths:
           description: ユーザー削除
       tags: *ref_0
       security: *ref_1
+  /api/users/token:
+    put:
+      operationId: updateUserToken
+      summary: ''
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateUserTokenDto'
+      responses:
+        '200':
+          description: トークンの更新
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserTokenPresenter'
+      tags: *ref_0
+      security: *ref_1
   /api/recipes:
     get:
       operationId: getRecipe
@@ -539,6 +559,26 @@ components:
         - name
         - imageUrl
         - activeStatus
+    UpdateUserTokenDto:
+      type: object
+      properties:
+        deviceId:
+          type: string
+        token:
+          type: string
+      required:
+        - deviceId
+        - token
+    UserTokenPresenter:
+      type: object
+      properties:
+        deviceId:
+          type: string
+        token:
+          type: string
+      required:
+        - deviceId
+        - token
     RecipePresenter:
       type: object
       properties:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,9 +52,23 @@ model User {
   requestedRecipes RequestedRecipe[]
   spaceId          String?           @map("space_id")
   space            Space?            @relation(fields: [spaceId], references: [spaceId], onDelete: Cascade)
+  UserToken        UserToken[]
 
   @@index([userId])
   @@map("users")
+}
+
+model UserToken {
+  userTokenId      String   @id @default(cuid()) @map("user_token_id")
+  token            String
+  deviceId         String   @map("device_id")
+  lastActive       DateTime @default(now()) @map("last_active")
+  userId           String   @map("user_id")
+  user             User     @relation(fields: [userId], references: [userId], onDelete: Cascade)
+
+  @@index([userTokenId])
+  @@index([userId])
+  @@map("user_tokens")
 }
 
 model SpaceInvitation {

--- a/src/controllers/user/user.dto.ts
+++ b/src/controllers/user/user.dto.ts
@@ -1,6 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsNotEmpty } from 'class-validator';
-import { ActiveStatus, UpdateUserDto as DomainUpdateUserDto } from 'src/domain';
+import {
+  ActiveStatus,
+  UpdateUserDto as DomainUpdateUserDto,
+  UpdateUserTokenDto as DomainUpdateUserTokenDto,
+} from 'src/domain';
 export class UpdateUserDto implements DomainUpdateUserDto {
   @ApiProperty()
   @IsString()
@@ -16,4 +20,16 @@ export class UpdateUserDto implements DomainUpdateUserDto {
   @IsString()
   @IsNotEmpty()
   activeStatus: ActiveStatus;
+}
+
+export class UpdateUserTokenDto implements DomainUpdateUserTokenDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  deviceId: string;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  token: string;
 }

--- a/src/controllers/user/user.presenter.ts
+++ b/src/controllers/user/user.presenter.ts
@@ -29,3 +29,16 @@ export class UserPresenter {
     this.spaceId = user.getSpaceId;
   }
 }
+
+export class UserTokenPresenter {
+  @ApiProperty()
+  readonly deviceId: string;
+
+  @ApiProperty()
+  readonly token: string;
+
+  constructor({ deviceId, token }: { deviceId: string; token: string }) {
+    this.deviceId = deviceId;
+    this.token = token;
+  }
+}

--- a/src/domain/user.ts
+++ b/src/domain/user.ts
@@ -1,5 +1,6 @@
 import { BadRequestException } from 'src/infrastructure/exceptions';
 import { SpaceInvitation } from './space';
+
 export enum SpaceRole {
   OWNER = 'OWNER',
   PARTICIPANT = 'PARTICIPANT',
@@ -140,6 +141,79 @@ export class User extends UserBeforePersist {
   }
 }
 
+export class UserTokenBeforePersist {
+  private token: string;
+  private deviceId: string;
+  private userId: string;
+  constructor({
+    userId,
+    deviceId,
+    token,
+  }: {
+    userId: string;
+    deviceId: string;
+    token: string;
+  }) {
+    this.userId = userId;
+    this.deviceId = deviceId;
+    this.token = token;
+  }
+  get getToken(): string {
+    return this.token;
+  }
+
+  get getDeviceId(): string {
+    return this.deviceId;
+  }
+
+  get getUserId(): string {
+    return this.userId;
+  }
+
+  set setToken(token: string) {
+    this.token = token;
+  }
+}
+
+export class UserToken extends UserTokenBeforePersist {
+  private id: string;
+  private lastActive: Date;
+  constructor({
+    id,
+    token,
+    deviceId,
+    lastActive,
+    userId,
+  }: {
+    id: string;
+    token: string;
+    deviceId: string;
+    lastActive: Date;
+    userId: string;
+  }) {
+    super({
+      userId,
+      deviceId,
+      token,
+    });
+    this.id = id;
+    this.setToken = token;
+    this.lastActive = lastActive;
+  }
+  get getId(): string {
+    return this.id;
+  }
+
+  get getLastActive(): Date {
+    return this.lastActive;
+  }
+
+  update(token: string): void {
+    this.setToken = token;
+    this.lastActive = new Date();
+  }
+}
+
 export type IUserRepository = {
   create(user: UserBeforePersist): Promise<User>;
   findUser(
@@ -149,8 +223,19 @@ export type IUserRepository = {
   updateWithSpace(user: User, invitation: SpaceInvitation): Promise<User>;
 };
 
+export type IUserTokenRepository = {
+  save(userTokenBeforePersist: UserTokenBeforePersist): Promise<UserToken>;
+  findUserToken(userId: string, deviceId: string): Promise<UserToken | null>;
+  findUserTokens(userId: string): Promise<UserToken[] | null>;
+};
+
 export type UpdateUserDto = {
   name: string;
   imageUrl: string;
   activeStatus: ActiveStatus;
+};
+
+export type UpdateUserTokenDto = {
+  deviceId: string;
+  token: string;
 };

--- a/src/infrastructure/database/database.module.ts
+++ b/src/infrastructure/database/database.module.ts
@@ -7,6 +7,7 @@ import {
   PrismaSpaceInvitationRepository,
   PrismaMenuRepository,
   PrismaRequestedRecipeRepository,
+  PrismaUserTokenRepository,
 } from './prisma';
 
 @Module({
@@ -18,6 +19,7 @@ import {
     PrismaSpaceInvitationRepository,
     PrismaMenuRepository,
     PrismaRequestedRecipeRepository,
+    PrismaUserTokenRepository,
   ],
   exports: [
     PrismaUserRepository,
@@ -26,6 +28,7 @@ import {
     PrismaSpaceInvitationRepository,
     PrismaMenuRepository,
     PrismaRequestedRecipeRepository,
+    PrismaUserTokenRepository,
   ],
 })
 export class DatabaseModule {}

--- a/src/infrastructure/database/prisma/index.ts
+++ b/src/infrastructure/database/prisma/index.ts
@@ -5,3 +5,4 @@ export * from './repositories/prisma.space.repository';
 export * from './repositories/prisma.space-invitation.repository';
 export * from './repositories/prisma.menu.repository';
 export * from './repositories/prisma.requested-recipe.repository';
+export * from './repositories/prisma.user-token.repository';

--- a/src/infrastructure/database/prisma/repositories/prisma.user-token.repository.ts
+++ b/src/infrastructure/database/prisma/repositories/prisma.user-token.repository.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/infrastructure/database/prisma/prisma.service';
+import {
+  IUserTokenRepository,
+  UserTokenBeforePersist,
+  UserToken,
+} from 'src/domain';
+import { UserToken as PrismaUserToken } from '@prisma/client';
+
+@Injectable()
+export class PrismaUserTokenRepository implements IUserTokenRepository {
+  constructor(private readonly prismaService: PrismaService) {
+    this.prismaService = prismaService;
+  }
+
+  async save(
+    userToken: UserToken | UserTokenBeforePersist,
+  ): Promise<UserToken> {
+    const prismaUserToken = await this.prismaService.userToken.upsert({
+      where: {
+        userTokenId: 'id' in userToken ? userToken.getId : '',
+      },
+      create: {
+        token: userToken.getToken,
+        deviceId: userToken.getDeviceId,
+        userId: userToken.getUserId,
+      },
+      update: {
+        token: userToken.getToken,
+        deviceId: userToken.getDeviceId,
+        userId: userToken.getUserId,
+      },
+    });
+
+    return this.toUserToken(prismaUserToken);
+  }
+
+  async findUserToken(
+    userId: string,
+    deviceId: string,
+  ): Promise<UserToken | null> {
+    const prismaUserToken = await this.prismaService.userToken.findFirst({
+      where: {
+        userId,
+        deviceId,
+      },
+    });
+    if (!prismaUserToken) {
+      return null;
+    }
+    return this.toUserToken(prismaUserToken);
+  }
+
+  async findUserTokens(userId: string): Promise<UserToken[] | null> {
+    const prismaUserTokens = await this.prismaService.userToken.findMany({
+      where: {
+        userId,
+      },
+    });
+    if (!prismaUserTokens.length) {
+      return null;
+    }
+    return prismaUserTokens.map((prismaUserToken) =>
+      this.toUserToken(prismaUserToken),
+    );
+  }
+
+  private toUserToken(prismaUserToken: PrismaUserToken) {
+    return new UserToken({
+      id: prismaUserToken.userTokenId,
+      token: prismaUserToken.token,
+      deviceId: prismaUserToken.deviceId,
+      lastActive: prismaUserToken.lastActive,
+      userId: prismaUserToken.userId,
+    });
+  }
+}

--- a/src/use-cases/update-user-token.use-case.ts
+++ b/src/use-cases/update-user-token.use-case.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { UpdateUserTokenDto } from 'src/controllers/user';
+import {
+  IUserTokenRepository,
+  UserToken,
+  UserTokenBeforePersist,
+} from 'src/domain';
+
+@Injectable()
+export class UpdateUserTokenUseCase {
+  constructor(private readonly userTokenRepository: IUserTokenRepository) {}
+  async execute(
+    userId: string,
+    updateUserDto: UpdateUserTokenDto,
+  ): Promise<UserToken> {
+    const userToken = await this.userTokenRepository.findUserToken(
+      userId,
+      updateUserDto.deviceId,
+    );
+    // userTokenがない場合は作成
+    if (!userToken) {
+      return await this.userTokenRepository.save(
+        new UserTokenBeforePersist({
+          userId,
+          deviceId: updateUserDto.deviceId,
+          token: updateUserDto.token,
+        }),
+      );
+    }
+    // userTokenがある場合は更新
+    userToken.update(updateUserDto.token);
+    return await this.userTokenRepository.save(userToken);
+  }
+}

--- a/src/use-cases/use-case.module.ts
+++ b/src/use-cases/use-case.module.ts
@@ -30,7 +30,9 @@ import {
   PrismaMenuRepository,
   PrismaSpaceRepository,
   PrismaRequestedRecipeRepository,
+  PrismaUserTokenRepository,
 } from 'src/infrastructure/database/prisma';
+import { UpdateUserTokenUseCase } from './update-user-token.use-case';
 
 export class UseCaseProxy<T> {
   constructor(private readonly useCase: T) {}
@@ -65,6 +67,7 @@ export class UseCaseProxyModule {
     'CREATE_REQUESTED_RECIPE_USE_CASE';
   static readonly DELETE_REQUESTED_RECIPE_USE_CASE =
     'DELETE_REQUESTED_RECIPE_USE_CASE';
+  static readonly UPDATE_USER_TOKEN_USE_CASE = 'UPDATE_USER_TOKEN_USE_CASE';
   static resister(): DynamicModule {
     return {
       module: UseCaseProxyModule,
@@ -237,6 +240,14 @@ export class UseCaseProxyModule {
               new DeleteRequestedRecipeUseCase(prismaRequestedRecipeRepository),
             ),
         },
+        {
+          inject: [PrismaUserTokenRepository],
+          provide: UseCaseProxyModule.UPDATE_USER_TOKEN_USE_CASE,
+          useFactory: (prismaUserTokenRepository: PrismaUserTokenRepository) =>
+            new UseCaseProxy(
+              new UpdateUserTokenUseCase(prismaUserTokenRepository),
+            ),
+        },
       ],
       exports: [
         UseCaseProxyModule.LOGIN_USE_CASE,
@@ -258,6 +269,7 @@ export class UseCaseProxyModule {
         UseCaseProxyModule.GET_RECIPE_META_DATE_USE_CASE,
         UseCaseProxyModule.CREATE_REQUESTED_RECIPE_USE_CASE,
         UseCaseProxyModule.DELETE_REQUESTED_RECIPE_USE_CASE,
+        UseCaseProxyModule.UPDATE_USER_TOKEN_USE_CASE,
       ],
     };
   }


### PR DESCRIPTION
# 概要

ユーザーにプッシュ通知を送るため、トークンを管理できるように変更しました。

プッシュ通知のトークンはデバイスごとに管理する必要があるので、ユーザーとトークンは1:Nの関係になる。
そのため、プッシュ通知用のトークンを管理するテーブルを作成し、トークンを更新するAPIを追加しました。

# 変更点

- `prisma.schema`を更新し、`UserToken`テーブルを追加
- `PUT /api/users/token`APIを追加

# チェックリスト
- [x] prisma.schemaの内容をsupabaseのテーブルに反映することが確認
- [x] アプリからリクエストし、期待したデータが挿入されることを確認