### PR TITLE
ユーザー情報更新で、filenameが抜けていたので追加

### DIFF
--- a/src/infrastructure/database/prisma/repositories/prisma.user.repository.ts
+++ b/src/infrastructure/database/prisma/repositories/prisma.user.repository.ts
@@ -8,7 +8,7 @@ import {
   SpaceRole,
   SpaceInvitation,
 } from 'src/domain';
-import { Prisma, User as PrismaUser } from '@prisma/client';
+import { User as PrismaUser } from '@prisma/client';
 
 export type FindOptions = { uid: string } | { userId: string };
 @Injectable()
@@ -68,6 +68,7 @@ export class PrismaUserRepository implements IUserRepository {
       data: {
         name: user.getName,
         imageUrl: user.getImageUrl,
+        filename: user.getFilename,
         activeStatus: user.getActiveStatus as ActiveStatus,
       },
     });

--- a/src/infrastructure/firebase/firebase.service.ts
+++ b/src/infrastructure/firebase/firebase.service.ts
@@ -90,7 +90,12 @@ export class FirebaseService implements OnModuleInit {
 
       // 元の画像を削除
       if (prevFilename?.length) {
-        await this.deleteImageFromStorage(prevFilename);
+        // 削除エラーは無視
+        try {
+          await this.deleteImageFromStorage(prevFilename);
+        } catch (err) {
+          console.error('Failed to delete image', err);
+        }
       }
     } catch (error) {
       throw new HttpException(


### PR DESCRIPTION
`user`テーブル更新時に、filenameが抜けていたことで最初に登録されたfilenameがずっと残っていた。
それが原因で、画像を変更時に、元画像を削除する箇所でエラーになり落ちていた。

そのため以下の変更を行った。
- ripository層で画像のfilenameを更新対象に加える
- 画像の削除に失敗しても、画像が登録できていれば処理を正常に通すように変更（画像の削除自体は最悪バッチ処理で消せば良いから）
