### PR TITLE
スペースの食べたいレシピを取得するAPIの追加

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -153,37 +153,18 @@ paths:
                 $ref: '#/components/schemas/RecipeMetaDataPresenter'
       tags: *ref_2
       security: *ref_3
-  /api/recipes/requests:
+  /api/recipes/user-group-requests:
     get:
-      operationId: getRequestedRecipes
+      operationId: getRequestedRecipesByUser
       summary: ''
       parameters: []
       responses:
         '200':
-          description: スペースの食べたいに設定したレシピ一覧取得
+          description: スペースの食べたいに設定したユーザーごとのレシピ一覧取得
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RequestedRecipePresenter'
-      tags: *ref_2
-      security: *ref_3
-    post:
-      operationId: createRequestedRecipe
-      summary: ''
-      parameters: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateRequestedRecipeDto'
-      responses:
-        '201':
-          description: リクエストレシピ登録
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SuccessPresenter'
+                $ref: '#/components/schemas/RequestedRecipePresenterByUser'
       tags: *ref_2
       security: *ref_3
   /api/recipes/{id}:
@@ -251,6 +232,26 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/RecipePresenter'
+      tags: *ref_2
+      security: *ref_3
+  /api/recipes/requests:
+    post:
+      operationId: createRequestedRecipe
+      summary: ''
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateRequestedRecipeDto'
+      responses:
+        '201':
+          description: リクエストレシピ登録
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessPresenter'
       tags: *ref_2
       security: *ref_3
   /api/recipes/{id}/requests:
@@ -680,7 +681,7 @@ components:
         - thumbnailUrl
         - appName
         - faviconUrl
-    RequestedRecipePresenter:
+    RequestedRecipePresenterByUser:
       type: object
       properties:
         data:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -153,6 +153,39 @@ paths:
                 $ref: '#/components/schemas/RecipeMetaDataPresenter'
       tags: *ref_2
       security: *ref_3
+  /api/recipes/requests:
+    get:
+      operationId: getRequestedRecipes
+      summary: ''
+      parameters: []
+      responses:
+        '200':
+          description: スペースの食べたいに設定したレシピ一覧取得
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestedRecipePresenter'
+      tags: *ref_2
+      security: *ref_3
+    post:
+      operationId: createRequestedRecipe
+      summary: ''
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateRequestedRecipeDto'
+      responses:
+        '201':
+          description: リクエストレシピ登録
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessPresenter'
+      tags: *ref_2
+      security: *ref_3
   /api/recipes/{id}:
     get:
       operationId: getRecipe
@@ -218,26 +251,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/RecipePresenter'
-      tags: *ref_2
-      security: *ref_3
-  /api/recipes/requests:
-    post:
-      operationId: createRequestedRecipe
-      summary: ''
-      parameters: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateRequestedRecipeDto'
-      responses:
-        '201':
-          description: リクエストレシピ登録
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SuccessPresenter'
       tags: *ref_2
       security: *ref_3
   /api/recipes/{id}/requests:
@@ -667,6 +680,15 @@ components:
         - thumbnailUrl
         - appName
         - faviconUrl
+    RequestedRecipePresenter:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/RecipePresenter'
+      required:
+        - data
     CreateRecipeDto:
       type: object
       properties:

--- a/src/controllers/recipe/recipe.controller.ts
+++ b/src/controllers/recipe/recipe.controller.ts
@@ -22,7 +22,7 @@ import {
   RecipePresenter,
   PaginatedRecipePresenter,
   RecipeMetaDataPresenter,
-  RequestedRecipePresenter,
+  RequestedRecipePresenterByUser,
 } from './recipe.presenter';
 import {
   CreateRecipeDto,
@@ -40,7 +40,7 @@ import {
   GetRecipeMetaDateUseCase,
   CreateRequestedRecipeUseCase,
   DeleteRequestedRecipeUseCase,
-  GetRequestedRecipeListUseCase,
+  GetRequestedRecipeListByUserUseCase,
 } from 'src/use-cases';
 import { Request } from 'express';
 import { SuccessPresenter } from '../common/success.presenter';
@@ -60,8 +60,8 @@ export class RecipeController {
     private readonly getRecipeDetailUseCase: UseCaseProxy<GetRecipeDetailUseCase>,
     @Inject(UseCaseProxyModule.GET_RECIPE_LIST_USE_CASE)
     private readonly getRecipeListUseCase: UseCaseProxy<GetRecipeListUseCase>,
-    @Inject(UseCaseProxyModule.GET_REQUESTED_RECIPE_LIST_USE_CASE)
-    private readonly getRequestedRecipeListUseCase: UseCaseProxy<GetRequestedRecipeListUseCase>,
+    @Inject(UseCaseProxyModule.GET_REQUESTED_RECIPE_LIST_BY_USER_USE_CASE)
+    private readonly getRequestedRecipeListByUserUseCase: UseCaseProxy<GetRequestedRecipeListByUserUseCase>,
     @Inject(UseCaseProxyModule.GET_RECIPE_META_DATE_USE_CASE)
     private readonly getRecipeMetaDataUseCase: UseCaseProxy<GetRecipeMetaDateUseCase>,
     @Inject(UseCaseProxyModule.CREATE_REQUESTED_RECIPE_USE_CASE)
@@ -130,19 +130,20 @@ export class RecipeController {
     );
   }
 
-  @Get('requests')
-  @ApiOperation({ operationId: 'getRequestedRecipes' })
+  @Get('user-group-requests')
+  @ApiOperation({ operationId: 'getRequestedRecipesByUser' })
   @ApiResponse({
     status: 200,
-    description: 'スペースの食べたいに設定したレシピ一覧取得',
-    type: RequestedRecipePresenter,
+    description: 'スペースの食べたいに設定したユーザーごとのレシピ一覧取得',
+    type: RequestedRecipePresenterByUser,
   })
   async getRequestedRecipes(@Req() req: Request) {
-    const recipes = await this.getRequestedRecipeListUseCase
-      .getInstance()
-      .execute(req.currentUser.getSpaceId);
+    const requestedRecipesByUser =
+      await this.getRequestedRecipeListByUserUseCase
+        .getInstance()
+        .execute(req.currentUser.getSpaceId);
 
-    return new RequestedRecipePresenter(recipes);
+    return new RequestedRecipePresenterByUser(requestedRecipesByUser);
   }
 
   @Get(':id')

--- a/src/controllers/recipe/recipe.controller.ts
+++ b/src/controllers/recipe/recipe.controller.ts
@@ -22,6 +22,7 @@ import {
   RecipePresenter,
   PaginatedRecipePresenter,
   RecipeMetaDataPresenter,
+  RequestedRecipePresenter,
 } from './recipe.presenter';
 import {
   CreateRecipeDto,
@@ -39,6 +40,7 @@ import {
   GetRecipeMetaDateUseCase,
   CreateRequestedRecipeUseCase,
   DeleteRequestedRecipeUseCase,
+  GetRequestedRecipeListUseCase,
 } from 'src/use-cases';
 import { Request } from 'express';
 import { SuccessPresenter } from '../common/success.presenter';
@@ -58,6 +60,8 @@ export class RecipeController {
     private readonly getRecipeDetailUseCase: UseCaseProxy<GetRecipeDetailUseCase>,
     @Inject(UseCaseProxyModule.GET_RECIPE_LIST_USE_CASE)
     private readonly getRecipeListUseCase: UseCaseProxy<GetRecipeListUseCase>,
+    @Inject(UseCaseProxyModule.GET_REQUESTED_RECIPE_LIST_USE_CASE)
+    private readonly getRequestedRecipeListUseCase: UseCaseProxy<GetRequestedRecipeListUseCase>,
     @Inject(UseCaseProxyModule.GET_RECIPE_META_DATE_USE_CASE)
     private readonly getRecipeMetaDataUseCase: UseCaseProxy<GetRecipeMetaDateUseCase>,
     @Inject(UseCaseProxyModule.CREATE_REQUESTED_RECIPE_USE_CASE)
@@ -124,6 +128,21 @@ export class RecipeController {
     return new RecipeMetaDataPresenter(
       await this.getRecipeMetaDataUseCase.getInstance().execute(recipeUrl),
     );
+  }
+
+  @Get('requests')
+  @ApiOperation({ operationId: 'getRequestedRecipes' })
+  @ApiResponse({
+    status: 200,
+    description: 'スペースの食べたいに設定したレシピ一覧取得',
+    type: RequestedRecipePresenter,
+  })
+  async getRequestedRecipes(@Req() req: Request) {
+    const recipes = await this.getRequestedRecipeListUseCase
+      .getInstance()
+      .execute(req.currentUser.getSpaceId);
+
+    return new RequestedRecipePresenter(recipes);
   }
 
   @Get(':id')

--- a/src/controllers/recipe/recipe.presenter.ts
+++ b/src/controllers/recipe/recipe.presenter.ts
@@ -74,11 +74,12 @@ export class PaginatedRecipePresenter {
   }
 }
 
-export class RequestedRecipePresenter {
+export class RequestedRecipePresenterByUser {
   @ApiProperty({ type: [RecipePresenter] })
   data: Record<string, Recipe[]>;
 
   constructor(data: Record<string, Recipe[]>) {
+    //NOTE: RecipePresenterと同じレスポンスデータにするため、valueのrequesters情報をオブジェクトからuserIdの文字列配列に変換
     const transformedData: Record<string, any[]> = {};
 
     Object.keys(data).forEach((key) => {
@@ -89,7 +90,7 @@ export class RequestedRecipePresenter {
 
         return {
           ...recipe,
-          requesters: newRequesters, // 変更したプロパティを追加
+          requesters: newRequesters,
         };
       });
     });

--- a/src/controllers/recipe/recipe.presenter.ts
+++ b/src/controllers/recipe/recipe.presenter.ts
@@ -74,6 +74,30 @@ export class PaginatedRecipePresenter {
   }
 }
 
+export class RequestedRecipePresenter {
+  @ApiProperty({ type: [RecipePresenter] })
+  data: Record<string, Recipe[]>;
+
+  constructor(data: Record<string, Recipe[]>) {
+    const transformedData: Record<string, any[]> = {};
+
+    Object.keys(data).forEach((key) => {
+      transformedData[key] = data[key].map((recipe) => {
+        const newRequesters = recipe.getRequesters.map(
+          (requester) => requester.getUserId,
+        );
+
+        return {
+          ...recipe,
+          requesters: newRequesters, // 変更したプロパティを追加
+        };
+      });
+    });
+
+    this.data = transformedData;
+  }
+}
+
 export class RecipeMetaDataPresenter {
   @ApiProperty()
   title?: string;

--- a/src/domain/recipe.ts
+++ b/src/domain/recipe.ts
@@ -255,6 +255,7 @@ export type IRecipeRepository = {
     spaceId: string,
     findRecipeOptions?: FindRecipeOptions,
   ): Promise<Recipe[]>;
+  findRequestedRecipes(spaceId: string): Promise<Recipe[]>;
 };
 
 export type IRequestedRecipeRepository = {

--- a/src/infrastructure/database/prisma/repositories/prisma.recipe.repository.ts
+++ b/src/infrastructure/database/prisma/repositories/prisma.recipe.repository.ts
@@ -77,6 +77,26 @@ export class PrismaRecipeRepository implements IRecipeRepository {
     return prismaRecipes.map((prismaRecipe) => this.toRecipe(prismaRecipe));
   }
 
+  async findRequestedRecipes(spaceId: string): Promise<Recipe[]> {
+    const prismaRecipes = await this.prismaService.recipe.findMany({
+      take: 100,
+      where: {
+        spaceId,
+        requestedRecipes: {
+          some: {},
+        },
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+      include: {
+        requestedRecipes: true,
+        user: true,
+      },
+    });
+    return prismaRecipes.map((prismaRecipe) => this.toRecipe(prismaRecipe));
+  }
+
   async bulkInsert(recipes: RecipeBeforePersist[]): Promise<Recipe[]> {
     const prismaRecipes = await this.prismaService.$transaction(
       recipes.map((recipe) =>

--- a/src/use-cases/get-requested-recipe-list-by-user.use-case.ts
+++ b/src/use-cases/get-requested-recipe-list-by-user.use-case.ts
@@ -2,8 +2,16 @@ import { Injectable } from '@nestjs/common';
 import { IRecipeRepository, Recipe } from 'src/domain';
 
 @Injectable()
-export class GetRequestedRecipeListUseCase {
+export class GetRequestedRecipeListByUserUseCase {
   constructor(private readonly recipeRepository: IRecipeRepository) {}
+
+  async execute(spaceId: string) {
+    const requestedRecipes = await this.recipeRepository.findRequestedRecipes(
+      spaceId,
+    );
+    return this.groupRecipesByUser(requestedRecipes);
+  }
+
   private groupRecipesByUser(recipes: Recipe[]) {
     const userRecipeMap: Record<string, Recipe[]> = {};
 
@@ -18,9 +26,5 @@ export class GetRequestedRecipeListUseCase {
     });
 
     return userRecipeMap;
-  }
-  async execute(spaceId: string) {
-    const recipes = await this.recipeRepository.findRequestedRecipes(spaceId);
-    return this.groupRecipesByUser(recipes);
   }
 }

--- a/src/use-cases/get-requested-recipe-list.use-case.ts
+++ b/src/use-cases/get-requested-recipe-list.use-case.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { IRecipeRepository, Recipe } from 'src/domain';
+
+@Injectable()
+export class GetRequestedRecipeListUseCase {
+  constructor(private readonly recipeRepository: IRecipeRepository) {}
+  private groupRecipesByUser(recipes: Recipe[]) {
+    const userRecipeMap: Record<string, Recipe[]> = {};
+
+    recipes.forEach((recipe) => {
+      recipe.getRequesters.forEach((requester) => {
+        if (!userRecipeMap[requester.getUserId]) {
+          userRecipeMap[requester.getUserId] = [];
+        }
+        // ユーザーごとにレシピ情報を追加
+        userRecipeMap[requester.getUserId].push(recipe);
+      });
+    });
+
+    return userRecipeMap;
+  }
+  async execute(spaceId: string) {
+    const recipes = await this.recipeRepository.findRequestedRecipes(spaceId);
+    return this.groupRecipesByUser(recipes);
+  }
+}

--- a/src/use-cases/index.ts
+++ b/src/use-cases/index.ts
@@ -13,7 +13,7 @@ export * from './update-menu.use-case';
 export * from './delete-menu.use-case';
 export * from './validate-recipe-book-join.use-case';
 export * from './get-recipe-list.use-case';
-export * from './get-requested-recipe-list.use-case';
+export * from './get-requested-recipe-list-by-user.use-case';
 export * from './get-menu-list.use-case';
 export * from './send-contact-to-slack.use-case';
 export * from './get-recipe-meta-data.use-case';

--- a/src/use-cases/index.ts
+++ b/src/use-cases/index.ts
@@ -13,6 +13,7 @@ export * from './update-menu.use-case';
 export * from './delete-menu.use-case';
 export * from './validate-recipe-book-join.use-case';
 export * from './get-recipe-list.use-case';
+export * from './get-requested-recipe-list.use-case';
 export * from './get-menu-list.use-case';
 export * from './send-contact-to-slack.use-case';
 export * from './get-recipe-meta-data.use-case';

--- a/src/use-cases/use-case.module.ts
+++ b/src/use-cases/use-case.module.ts
@@ -14,6 +14,7 @@ import {
   DeleteMenuUseCase,
   ValidateSpaceJoinUseCase,
   GetRecipeListUseCase,
+  GetRequestedRecipeListUseCase,
   GetMenuListUseCase,
   SendContactToSlackUseCase,
   GetRecipeMetaDateUseCase,
@@ -61,6 +62,8 @@ export class UseCaseProxyModule {
   static readonly DELETE_MENU_USE_CASE = 'DELETE_MENU_USE_CASE';
   static readonly VALIDATE_SPACE_JOIN_USE_CASE = 'VALIDATE_SPACE_JOIN_USE_CASE';
   static readonly GET_RECIPE_LIST_USE_CASE = 'GET_RECIPE_LIST_USE_CASE';
+  static readonly GET_REQUESTED_RECIPE_LIST_USE_CASE =
+    'GET_REQUESTED_RECIPE_LIST_USE_CASE';
   static readonly GET_MENU_LIST_USE_CASE = 'GET_MENU_LIST_USE_CASE';
   static readonly SEND_CONTACT_TO_SLACK_USE_CASE =
     'SEND_CONTACT_TO_SLACK_USE_CASE';
@@ -212,6 +215,14 @@ export class UseCaseProxyModule {
             new UseCaseProxy(new GetRecipeListUseCase(recipeRepository)),
         },
         {
+          inject: [PrismaRecipeRepository],
+          provide: UseCaseProxyModule.GET_REQUESTED_RECIPE_LIST_USE_CASE,
+          useFactory: (recipeRepository: PrismaRecipeRepository) =>
+            new UseCaseProxy(
+              new GetRequestedRecipeListUseCase(recipeRepository),
+            ),
+        },
+        {
           inject: [PrismaMenuRepository],
           provide: UseCaseProxyModule.GET_MENU_LIST_USE_CASE,
           useFactory: (menuRepository: PrismaMenuRepository) =>
@@ -298,6 +309,7 @@ export class UseCaseProxyModule {
         UseCaseProxyModule.DELETE_MENU_USE_CASE,
         UseCaseProxyModule.VALIDATE_SPACE_JOIN_USE_CASE,
         UseCaseProxyModule.GET_RECIPE_LIST_USE_CASE,
+        UseCaseProxyModule.GET_REQUESTED_RECIPE_LIST_USE_CASE,
         UseCaseProxyModule.GET_MENU_LIST_USE_CASE,
         UseCaseProxyModule.SEND_CONTACT_TO_SLACK_USE_CASE,
         UseCaseProxyModule.GET_RECIPE_META_DATE_USE_CASE,

--- a/src/use-cases/use-case.module.ts
+++ b/src/use-cases/use-case.module.ts
@@ -14,7 +14,7 @@ import {
   DeleteMenuUseCase,
   ValidateSpaceJoinUseCase,
   GetRecipeListUseCase,
-  GetRequestedRecipeListUseCase,
+  GetRequestedRecipeListByUserUseCase,
   GetMenuListUseCase,
   SendContactToSlackUseCase,
   GetRecipeMetaDateUseCase,
@@ -62,8 +62,8 @@ export class UseCaseProxyModule {
   static readonly DELETE_MENU_USE_CASE = 'DELETE_MENU_USE_CASE';
   static readonly VALIDATE_SPACE_JOIN_USE_CASE = 'VALIDATE_SPACE_JOIN_USE_CASE';
   static readonly GET_RECIPE_LIST_USE_CASE = 'GET_RECIPE_LIST_USE_CASE';
-  static readonly GET_REQUESTED_RECIPE_LIST_USE_CASE =
-    'GET_REQUESTED_RECIPE_LIST_USE_CASE';
+  static readonly GET_REQUESTED_RECIPE_LIST_BY_USER_USE_CASE =
+    'GET_REQUESTED_RECIPE_LIST_BY_USER_USE_CASE';
   static readonly GET_MENU_LIST_USE_CASE = 'GET_MENU_LIST_USE_CASE';
   static readonly SEND_CONTACT_TO_SLACK_USE_CASE =
     'SEND_CONTACT_TO_SLACK_USE_CASE';
@@ -216,10 +216,11 @@ export class UseCaseProxyModule {
         },
         {
           inject: [PrismaRecipeRepository],
-          provide: UseCaseProxyModule.GET_REQUESTED_RECIPE_LIST_USE_CASE,
+          provide:
+            UseCaseProxyModule.GET_REQUESTED_RECIPE_LIST_BY_USER_USE_CASE,
           useFactory: (recipeRepository: PrismaRecipeRepository) =>
             new UseCaseProxy(
-              new GetRequestedRecipeListUseCase(recipeRepository),
+              new GetRequestedRecipeListByUserUseCase(recipeRepository),
             ),
         },
         {
@@ -309,7 +310,7 @@ export class UseCaseProxyModule {
         UseCaseProxyModule.DELETE_MENU_USE_CASE,
         UseCaseProxyModule.VALIDATE_SPACE_JOIN_USE_CASE,
         UseCaseProxyModule.GET_RECIPE_LIST_USE_CASE,
-        UseCaseProxyModule.GET_REQUESTED_RECIPE_LIST_USE_CASE,
+        UseCaseProxyModule.GET_REQUESTED_RECIPE_LIST_BY_USER_USE_CASE,
         UseCaseProxyModule.GET_MENU_LIST_USE_CASE,
         UseCaseProxyModule.SEND_CONTACT_TO_SLACK_USE_CASE,
         UseCaseProxyModule.GET_RECIPE_META_DATE_USE_CASE,


### PR DESCRIPTION
トップページで、スペースの食べたいレシピを取得したく、APIを追加しました。

![CleanShot 2024-07-14 at 12 06 19@2x](https://github.com/user-attachments/assets/703f9fc4-44f4-4467-9c0c-8b02513700de)

食べたい料理に関しては、早いうちに上限を設けたいと思っています。今の時点では全てとるように、最大100件取得するようにしています。

## TODO
recipe.presenterのところでrequestersをフロントに返すように変換したく、recipeの型を定義したいが、どう定義したらいいかを相談したい。