### PR TITLE
オプショナルな数値型の変換用のパイプを追加

### DIFF
--- a/src/controllers/recipe/recipe.controller.ts
+++ b/src/controllers/recipe/recipe.controller.ts
@@ -10,6 +10,7 @@ import {
   Query,
   Delete,
   ParseIntPipe,
+  DefaultValuePipe,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -46,6 +47,7 @@ import {
 } from 'src/use-cases';
 import { Request } from 'express';
 import { SuccessPresenter } from '../common/success.presenter';
+import { ParseOptionalIntPipe } from 'src/pipes/parseOptionalInt.pipe';
 
 @ApiTags('recipes')
 @ApiBearerAuth()
@@ -98,7 +100,8 @@ export class RecipeController {
   })
   async index(
     @Req() req: Request,
-    @Query('cursor', ParseIntPipe) cursor: number | undefined,
+    @Query('cursor', new DefaultValuePipe(''), ParseOptionalIntPipe)
+    cursor: number | undefined,
     @Query('isRequested') isRequested: boolean | undefined,
     @Query('title') title: string | undefined,
   ) {

--- a/src/functions/getEnvFilePath.ts
+++ b/src/functions/getEnvFilePath.ts
@@ -1,8 +1,10 @@
 import { existsSync } from 'fs';
 import { resolve } from 'path';
+import * as functions from 'firebase-functions';
 
 export const getEnvFilePath = (envFilesDirectory: string): string => {
-  const env = process.env.NODE_ENV || 'development'; // Default to 'development' if NODE_ENV is not set
+  const firebaseEnv = functions.config().envs.firebase_env;
+  const env = firebaseEnv ? firebaseEnv : process.env.NODE_ENV || 'development'; // Default to 'development' if NODE_ENV is not set
   const fileName = `.env.${env}`;
   const filePath = resolve(`${envFilesDirectory}/${fileName}`);
   return existsSync(filePath)

--- a/src/functions/getEnvFilePath.ts
+++ b/src/functions/getEnvFilePath.ts
@@ -3,7 +3,7 @@ import { resolve } from 'path';
 import * as functions from 'firebase-functions';
 
 export const getEnvFilePath = (envFilesDirectory: string): string => {
-  const firebaseEnv = functions.config().envs.firebase_env;
+  const firebaseEnv = functions.config().envs?.firebase_env;
   const env = firebaseEnv ? firebaseEnv : process.env.NODE_ENV || 'development'; // Default to 'development' if NODE_ENV is not set
   const fileName = `.env.${env}`;
   const filePath = resolve(`${envFilesDirectory}/${fileName}`);

--- a/src/infrastructure/database/prisma/prisma.service.ts
+++ b/src/infrastructure/database/prisma/prisma.service.ts
@@ -49,4 +49,7 @@ export class PrismaService
     });
     await this.$connect();
   }
+  async onModuleDestroy() {
+    await this.$disconnect();
+  }
 }

--- a/src/infrastructure/firebase/firebase.service.ts
+++ b/src/infrastructure/firebase/firebase.service.ts
@@ -25,7 +25,7 @@ export class FirebaseService implements OnModuleInit {
   }
 
   get storage() {
-    return admin.storage();
+    return this.admin.storage();
   }
 
   async deleteImageFromStorage(filename: string) {

--- a/src/pipes/parseOptionalInt.pipe.ts
+++ b/src/pipes/parseOptionalInt.pipe.ts
@@ -1,0 +1,19 @@
+import { PipeTransform, Injectable, BadRequestException } from '@nestjs/common';
+
+@Injectable()
+export class ParseOptionalIntPipe
+  implements PipeTransform<string, number | undefined>
+{
+  transform(value: string): number | undefined {
+    if (value === '') {
+      return undefined;
+    }
+    const val = parseInt(value, 10);
+    if (isNaN(val)) {
+      throw new BadRequestException(
+        'Validation failed (numeric string is expected)',
+      );
+    }
+    return val;
+  }
+}

--- a/src/use-cases/login.use-case.ts
+++ b/src/use-cases/login.use-case.ts
@@ -13,7 +13,7 @@ export class LoginUseCase {
   private async processUserDto(decodedToken: DecodedIdToken) {
     const { name, uid, picture } = decodedToken;
     const userObject = {
-      name,
+      name: name || '',
       imageUrl: '',
       filename: '',
       uid,


### PR DESCRIPTION
# 現象

レシピ取得APIのクエリパラメーターの`cursor`が、undefinedの場合に`Validation failed (numeric string is expected)`というエラーが発生していた。

# 原因

nestjsが提供する`ParseIntPipe`が`undefined`の場合にNaNとして認識し、上記エラーを出力していた

# 対応

カスタムパイプを作成し、オプショナルなnumber型への変換を行うように修正した